### PR TITLE
Feat/dcmfoss 71_Favorite_service

### DIFF
--- a/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/controllers/FavoriteController.java
+++ b/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/controllers/FavoriteController.java
@@ -40,12 +40,14 @@ public class FavoriteController implements FavoriteApi {
 
     @Override
     public ResponseEntity<FavoriteResponse> createFavorite(FavoriteRequest favoriteRequest) throws Exception {
-        return null;
+        FavoriteResponse response = favoriteService.createFavorite(favoriteRequest);
+        return ResponseEntity.status(200).body(response);
     }
 
     @Override
-    public ResponseEntity<Void> deleteFavoriteById(String id) throws Exception {
-        return null;
+    public ResponseEntity<Void> deleteFavoriteById(String id, String type) throws Exception {
+        favoriteService.deleteFavorite(id,type);
+        return ResponseEntity.status(200).build();
     }
 
     @Override

--- a/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/controllers/FavoriteController.java
+++ b/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/controllers/FavoriteController.java
@@ -26,11 +26,13 @@ import eclipse.tractusx.demand_capacity_mgmt_specification.api.FavoriteApi;
 import eclipse.tractusx.demand_capacity_mgmt_specification.model.FavoriteRequest;
 import eclipse.tractusx.demand_capacity_mgmt_specification.model.FavoriteResponse;
 import lombok.AllArgsConstructor;
+import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.entities.enums.FavoriteType;
 import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.services.FavoriteService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @AllArgsConstructor
@@ -45,23 +47,26 @@ public class FavoriteController implements FavoriteApi {
     }
 
     @Override
-    public ResponseEntity<Void> deleteFavoriteById(String id, String type) throws Exception {
-        favoriteService.deleteFavorite(id,type);
+    public ResponseEntity<Void> deleteFavoriteById(String id) throws Exception {
+        favoriteService.deleteFavorite(UUID.fromString(id));
         return ResponseEntity.status(200).build();
     }
 
     @Override
     public ResponseEntity<List<FavoriteResponse>> getFavorite() throws Exception {
-        return null;
+        List<FavoriteResponse> responseList = favoriteService.getAllFavorites();
+        return ResponseEntity.status(200).body(responseList);
     }
 
     @Override
     public ResponseEntity<List<FavoriteResponse>> getFavoriteByType(String type) throws Exception {
-        return null;
+        List<FavoriteResponse> responseList = favoriteService.getAllFavoritesByType(type);
+        return ResponseEntity.status(200).body(responseList);
     }
 
     @Override
-    public ResponseEntity<FavoriteResponse> updateFavorite(FavoriteRequest favoriteRequest) throws Exception {
-        return null;
+    public ResponseEntity<FavoriteResponse> updateFavorite(String id,String type, FavoriteRequest favoriteRequest) throws Exception {
+        FavoriteResponse response = favoriteService.updateFavorite(UUID.fromString(id), FavoriteType.valueOf(type),favoriteRequest);
+        return ResponseEntity.status(200).body(response);
     }
 }

--- a/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/controllers/FavoriteController.java
+++ b/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/controllers/FavoriteController.java
@@ -1,0 +1,65 @@
+/*
+ * ******************************************************************************
+ * Copyright (c) 2023 BMW AG
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * *******************************************************************************
+ */
+
+package org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.controllers;
+
+import eclipse.tractusx.demand_capacity_mgmt_specification.api.FavoriteApi;
+import eclipse.tractusx.demand_capacity_mgmt_specification.model.FavoriteRequest;
+import eclipse.tractusx.demand_capacity_mgmt_specification.model.FavoriteResponse;
+import lombok.AllArgsConstructor;
+import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.services.FavoriteService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@AllArgsConstructor
+public class FavoriteController implements FavoriteApi {
+
+    private final FavoriteService favoriteService;
+
+    @Override
+    public ResponseEntity<FavoriteResponse> createFavorite(FavoriteRequest favoriteRequest) throws Exception {
+        return null;
+    }
+
+    @Override
+    public ResponseEntity<Void> deleteFavoriteById(String id) throws Exception {
+        return null;
+    }
+
+    @Override
+    public ResponseEntity<List<FavoriteResponse>> getFavorite() throws Exception {
+        return null;
+    }
+
+    @Override
+    public ResponseEntity<List<FavoriteResponse>> getFavoriteByType(String type) throws Exception {
+        return null;
+    }
+
+    @Override
+    public ResponseEntity<FavoriteResponse> updateFavorite(FavoriteRequest favoriteRequest) throws Exception {
+        return null;
+    }
+}

--- a/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/entities/FavoriteEntity.java
+++ b/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/entities/FavoriteEntity.java
@@ -45,7 +45,7 @@ public class FavoriteEntity {
     private UUID id;
 
     @Column(columnDefinition = "uuid",name = "favorite_id")
-    private UUID capacityGroupId;
+    private UUID favoriteId;
 
     @Column(name = "f_type")
     private FavoriteType type;

--- a/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/entities/FavoriteEntity.java
+++ b/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/entities/FavoriteEntity.java
@@ -47,6 +47,7 @@ public class FavoriteEntity {
     @Column(columnDefinition = "uuid",name = "favorite_id")
     private UUID favoriteId;
 
-    @Column(name = "f_type")
+    @Column(name = "f_type", columnDefinition = "varchar")
+    @Enumerated(EnumType.STRING)
     private FavoriteType type;
 }

--- a/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/entities/FavoriteEntity.java
+++ b/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/entities/FavoriteEntity.java
@@ -1,0 +1,52 @@
+/*
+ * ******************************************************************************
+ * Copyright (c) 2023 BMW AG
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * *******************************************************************************
+ */
+
+package org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.entities;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.entities.enums.FavoriteType;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@Entity
+@Table(name = "favorites")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FavoriteEntity {
+
+    @Id
+    @GeneratedValue
+    @Column(columnDefinition = "uuid", updatable = false, name = "user_id")
+    private UUID id;
+
+    @Column(columnDefinition = "uuid",name = "favorite_id")
+    private UUID capacityGroupId;
+
+    @Column(name = "f_type")
+    private FavoriteType type;
+}

--- a/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/entities/enums/FavoriteType.java
+++ b/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/entities/enums/FavoriteType.java
@@ -24,9 +24,15 @@ package org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.entiti
 
 public enum FavoriteType {
     CAPACITY_GROUP,
-    DEMAND,
+    CAPACITY_TIME_SERIES,
+    COMPANY_BASE_DATA,
+    DEMAND_CATEGORY,
+    DEMAND_SERIES,
+    DEMAND_SERIES_VALUES,
+    LINK_DEMAND,
+    LINKED_DEMAND_SERIES,
     MATERIAL_DEMAND,
-    PRODUCT,
-    UNIT_MEASURE
-
+    UNITY_OF_MEASURE,
+    WEEK_BASED_MATERIAL_DEMAND,
+    WEEK_BASED,CAPACITY,
 }

--- a/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/entities/enums/FavoriteType.java
+++ b/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/entities/enums/FavoriteType.java
@@ -1,0 +1,32 @@
+/*
+ * ******************************************************************************
+ * Copyright (c) 2023 BMW AG
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * *******************************************************************************
+ */
+
+package org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.entities.enums;
+
+public enum FavoriteType {
+    CAPACITY_GROUP,
+    DEMAND,
+    MATERIAL_DEMAND,
+    PRODUCT,
+    UNIT_MEASURE
+
+}

--- a/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/repositories/FavoriteRepository.java
+++ b/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/repositories/FavoriteRepository.java
@@ -23,9 +23,12 @@
 package org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.repositories;
 
 import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.entities.FavoriteEntity;
+import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.entities.enums.FavoriteType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface FavoriteRepository extends JpaRepository<FavoriteEntity, UUID> {
+    List<FavoriteEntity> findByType(FavoriteType type);
 }

--- a/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/repositories/FavoriteRepository.java
+++ b/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/repositories/FavoriteRepository.java
@@ -1,0 +1,31 @@
+/*
+ * ******************************************************************************
+ * Copyright (c) 2023 BMW AG
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * *******************************************************************************
+ */
+
+package org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.repositories;
+
+import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.entities.FavoriteEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface FavoriteRepository extends JpaRepository<FavoriteEntity, UUID> {
+}

--- a/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/repositories/FavoriteRepository.java
+++ b/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/repositories/FavoriteRepository.java
@@ -25,10 +25,12 @@ package org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.reposi
 import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.entities.FavoriteEntity;
 import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.entities.enums.FavoriteType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.lang.NonNull;
 
 import java.util.List;
 import java.util.UUID;
 
 public interface FavoriteRepository extends JpaRepository<FavoriteEntity, UUID> {
+    void deleteByTypeAndFavoriteId(@NonNull FavoriteType type, @NonNull UUID favoriteId);
     List<FavoriteEntity> findByType(FavoriteType type);
 }

--- a/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/repositories/FavoriteRepository.java
+++ b/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/repositories/FavoriteRepository.java
@@ -27,10 +27,24 @@ import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.entitie
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.lang.NonNull;
 
+import javax.transaction.Transactional;
 import java.util.List;
 import java.util.UUID;
 
 public interface FavoriteRepository extends JpaRepository<FavoriteEntity, UUID> {
-    void deleteByTypeAndFavoriteId(@NonNull FavoriteType type, @NonNull UUID favoriteId);
+
+    /* *
+    *
+    * We need @Transaction because we don't fetch the entity first
+    * that way Hibernate entity manager won't be blocked because of missing entity manager
+    * (since we don't fetch the entity at all we just send delete command)
+    *
+    *  */
+    @Transactional
+    void deleteByFavoriteIdAndId(@NonNull UUID favoriteId, @NonNull UUID id);
+
+    FavoriteEntity findByFavoriteIdAndTypeAndId(@NonNull UUID favoriteId, @NonNull FavoriteType type, @NonNull UUID id);
+
     List<FavoriteEntity> findByType(FavoriteType type);
+
 }

--- a/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/services/FavoriteService.java
+++ b/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/services/FavoriteService.java
@@ -23,23 +23,15 @@
 package org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.services;
 
 import eclipse.tractusx.demand_capacity_mgmt_specification.model.FavoriteRequest;
-import eclipse.tractusx.demand_capacity_mgmt_specification.model.MaterialDemandRequest;
-import eclipse.tractusx.demand_capacity_mgmt_specification.model.MaterialDemandResponse;
-import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.entities.MaterialDemandEntity;
-import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.entities.enums.MaterialDemandStatus;
+import eclipse.tractusx.demand_capacity_mgmt_specification.model.FavoriteResponse;
+import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.entities.enums.FavoriteType;
 
 import java.util.List;
 
 public interface FavoriteService {
-    FavoriteRequest createFavorite(FavoriteRequest favoriteRequest);
-
-    List<FavoriteRequest> getAllFavorites();
-
-    MaterialDemandResponse getDemandById(String demandId);
-
-    MaterialDemandResponse updateDemand(String demandId, MaterialDemandRequest materialDemandRequest);
-
-    void deleteDemandById(String demandId);
-
-    List<MaterialDemandEntity> getAllByStatus(MaterialDemandStatus status);
+    List<FavoriteResponse> getAllFavorites();
+    List<FavoriteResponse> getAllFavoritesByType(FavoriteType type);
+    FavoriteResponse createFavorite(FavoriteRequest favoriteRequest);
+    FavoriteResponse updateFavorite(FavoriteRequest favoriteRequest);
+    void deleteFavorite(FavoriteRequest favoriteRequest);
 }

--- a/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/services/FavoriteService.java
+++ b/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/services/FavoriteService.java
@@ -27,11 +27,12 @@ import eclipse.tractusx.demand_capacity_mgmt_specification.model.FavoriteRespons
 import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.entities.enums.FavoriteType;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface FavoriteService {
     List<FavoriteResponse> getAllFavorites();
-    List<FavoriteResponse> getAllFavoritesByType(FavoriteType type);
+    List<FavoriteResponse> getAllFavoritesByType(String type);
     FavoriteResponse createFavorite(FavoriteRequest favoriteRequest);
-    FavoriteResponse updateFavorite(FavoriteRequest favoriteRequest);
-    void deleteFavorite(String id, String type);
+    FavoriteResponse updateFavorite(UUID id, FavoriteType type, FavoriteRequest favoriteRequest);
+    void deleteFavorite(UUID id);
 }

--- a/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/services/FavoriteService.java
+++ b/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/services/FavoriteService.java
@@ -1,0 +1,44 @@
+/*
+ *  *******************************************************************************
+ *  Copyright (c) 2023 BMW AG
+ *  Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ *    See the NOTICE file(s) distributed with this work for additional
+ *    information regarding copyright ownership.
+ *
+ *    This program and the accompanying materials are made available under the
+ *    terms of the Apache License, Version 2.0 which is available at
+ *    https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ *    ********************************************************************************
+ */
+
+package org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.services;
+
+import eclipse.tractusx.demand_capacity_mgmt_specification.model.MaterialDemandRequest;
+import eclipse.tractusx.demand_capacity_mgmt_specification.model.MaterialDemandResponse;
+import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.entities.MaterialDemandEntity;
+import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.entities.enums.MaterialDemandStatus;
+
+import java.util.List;
+
+public interface FavoriteService {
+    MaterialDemandResponse createDemand(MaterialDemandRequest materialDemandRequest);
+
+    List<MaterialDemandResponse> getAllDemandsByProjectId();
+
+    MaterialDemandResponse getDemandById(String demandId);
+
+    MaterialDemandResponse updateDemand(String demandId, MaterialDemandRequest materialDemandRequest);
+
+    void deleteDemandById(String demandId);
+
+    List<MaterialDemandEntity> getAllByStatus(MaterialDemandStatus status);
+}

--- a/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/services/FavoriteService.java
+++ b/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/services/FavoriteService.java
@@ -22,6 +22,7 @@
 
 package org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.services;
 
+import eclipse.tractusx.demand_capacity_mgmt_specification.model.FavoriteRequest;
 import eclipse.tractusx.demand_capacity_mgmt_specification.model.MaterialDemandRequest;
 import eclipse.tractusx.demand_capacity_mgmt_specification.model.MaterialDemandResponse;
 import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.entities.MaterialDemandEntity;
@@ -30,9 +31,9 @@ import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.entitie
 import java.util.List;
 
 public interface FavoriteService {
-    MaterialDemandResponse createDemand(MaterialDemandRequest materialDemandRequest);
+    FavoriteRequest createFavorite(FavoriteRequest favoriteRequest);
 
-    List<MaterialDemandResponse> getAllDemandsByProjectId();
+    List<FavoriteRequest> getAllFavorites();
 
     MaterialDemandResponse getDemandById(String demandId);
 

--- a/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/services/FavoriteService.java
+++ b/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/services/FavoriteService.java
@@ -33,5 +33,5 @@ public interface FavoriteService {
     List<FavoriteResponse> getAllFavoritesByType(FavoriteType type);
     FavoriteResponse createFavorite(FavoriteRequest favoriteRequest);
     FavoriteResponse updateFavorite(FavoriteRequest favoriteRequest);
-    void deleteFavorite(FavoriteRequest favoriteRequest);
+    void deleteFavorite(String id, String type);
 }

--- a/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/services/impl/FavoriteServiceImpl.java
+++ b/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/services/impl/FavoriteServiceImpl.java
@@ -28,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.entities.FavoriteEntity;
 import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.entities.enums.FavoriteType;
+import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.exceptions.NotFoundException;
 import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.repositories.FavoriteRepository;
 import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.services.FavoriteService;
 import org.springframework.stereotype.Service;
@@ -42,6 +43,8 @@ public class FavoriteServiceImpl implements FavoriteService {
 
     private final FavoriteRepository favoriteRepository;
 
+    //TODO IMPLEMENT USER_ID IN OPERATIONS
+
     @Override
     public List<FavoriteResponse> getAllFavorites() {
         List<FavoriteEntity> favoriteEntities = favoriteRepository.findAll();
@@ -49,8 +52,8 @@ public class FavoriteServiceImpl implements FavoriteService {
     }
 
     @Override
-    public List<FavoriteResponse> getAllFavoritesByType(FavoriteType type) {
-        List<FavoriteEntity> favoriteEntities = favoriteRepository.findByType(type);
+    public List<FavoriteResponse> getAllFavoritesByType(String type) {
+        List<FavoriteEntity> favoriteEntities = favoriteRepository.findByType(FavoriteType.valueOf(type));
         return favoriteEntities.stream().map(this::convertFavoriteResponse).toList();
     }
 
@@ -61,16 +64,28 @@ public class FavoriteServiceImpl implements FavoriteService {
     }
 
     @Override
-    public FavoriteResponse updateFavorite(FavoriteRequest favoriteRequest) {
-        FavoriteEntity entity = favoriteRepository.save(generateFavoriteEntity(favoriteRequest));
-        return convertFavoriteResponse(entity);
-    }
+    public FavoriteResponse updateFavorite(UUID id, FavoriteType type, FavoriteRequest favoriteRequest) {
+        FavoriteEntity entity = favoriteRepository.findByFavoriteIdAndTypeAndId(
+                id,
+                type,
+                UUID.fromString("8842f835-38e9-42b1-8c07-fb310b90ef3a")); //TODO FETCH USER ID TO UPDATE OPERATION
 
+        if(entity != null){
+            entity.setFavoriteId(UUID.fromString(favoriteRequest.getFavoriteId()));
+            entity.setType(FavoriteType.valueOf(favoriteRequest.getfType()));
+            favoriteRepository.saveAndFlush(entity);
+            return convertFavoriteResponse(entity);
+        } else throw new NotFoundException(
+                "Entity to update was not found in DB."
+                        + "\n" +
+                "Did you meant to create?");
+    }
     @Override
-    public void deleteFavorite(String id, String type) {
-        favoriteRepository.deleteByTypeAndFavoriteId(
-                FavoriteType.valueOf(type),
-                UUID.fromString(id)
+    public void deleteFavorite(UUID id) {
+        //TODO PLACE USER ID IN HERE
+        favoriteRepository.deleteByFavoriteIdAndId(
+                id,
+                UUID.fromString("8842f835-38e9-42b1-8c07-fb310b90ef3a")
         );
     }
 

--- a/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/services/impl/FavoriteServiceImpl.java
+++ b/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/services/impl/FavoriteServiceImpl.java
@@ -1,0 +1,76 @@
+/*
+ * ******************************************************************************
+ * Copyright (c) 2023 BMW AG
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * *******************************************************************************
+ */
+
+package org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.services.impl;
+
+import eclipse.tractusx.demand_capacity_mgmt_specification.model.FavoriteRequest;
+import eclipse.tractusx.demand_capacity_mgmt_specification.model.FavoriteResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.entities.FavoriteEntity;
+import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.entities.enums.FavoriteType;
+import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.repositories.FavoriteRepository;
+import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.services.FavoriteService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class FavoriteServiceImpl implements FavoriteService {
+
+    private final FavoriteRepository favoriteRepository;
+
+    @Override
+    public List<FavoriteResponse> getAllFavorites() {
+        List<FavoriteEntity> favoriteEntities = favoriteRepository.findAll();
+        return favoriteEntities.stream().map(this::convertFavoriteResponse).toList();
+    }
+
+    @Override
+    public List<FavoriteResponse> getAllFavoritesByType(FavoriteType type) {
+        return null;
+    }
+
+    @Override
+    public FavoriteResponse createFavorite(FavoriteRequest favoriteRequest) {
+        return null;
+    }
+
+    @Override
+    public FavoriteResponse updateFavorite(FavoriteRequest favoriteRequest) {
+        return null;
+    }
+
+    @Override
+    public void deleteFavorite(FavoriteRequest favoriteRequest) {
+
+    }
+
+    private FavoriteResponse convertFavoriteResponse(FavoriteEntity request){
+        FavoriteResponse response = new FavoriteResponse();
+        response.setFavoriteId(request.getId().toString());
+        response.setfType(request.getType().name());
+        return response;
+    }
+}

--- a/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/services/impl/FavoriteServiceImpl.java
+++ b/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/services/impl/FavoriteServiceImpl.java
@@ -33,6 +33,7 @@ import org.eclipse.tractusx.demandcapacitymgmt.demandcapacitymgmtbackend.service
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.UUID;
 
 @RequiredArgsConstructor
 @Service
@@ -55,17 +56,22 @@ public class FavoriteServiceImpl implements FavoriteService {
 
     @Override
     public FavoriteResponse createFavorite(FavoriteRequest favoriteRequest) {
-        return null;
+        FavoriteEntity entity = favoriteRepository.save(generateFavoriteEntity(favoriteRequest));
+        return convertFavoriteResponse(entity);
     }
 
     @Override
     public FavoriteResponse updateFavorite(FavoriteRequest favoriteRequest) {
-        return null;
+        FavoriteEntity entity = favoriteRepository.save(generateFavoriteEntity(favoriteRequest));
+        return convertFavoriteResponse(entity);
     }
 
     @Override
-    public void deleteFavorite(FavoriteRequest favoriteRequest) {
-
+    public void deleteFavorite(String id, String type) {
+        favoriteRepository.deleteByTypeAndFavoriteId(
+                FavoriteType.valueOf(type),
+                UUID.fromString(id)
+        );
     }
 
     private FavoriteResponse convertFavoriteResponse(FavoriteEntity request){
@@ -73,5 +79,13 @@ public class FavoriteServiceImpl implements FavoriteService {
         response.setFavoriteId(request.getId().toString());
         response.setfType(request.getType().name());
         return response;
+    }
+
+    private FavoriteEntity generateFavoriteEntity(FavoriteRequest request){
+        return FavoriteEntity.builder()
+                .id(UUID.randomUUID())//TODO USER ID HERE
+                .favoriteId(UUID.fromString(request.getFavoriteId()))
+                .type(FavoriteType.valueOf(request.getfType()))
+                .build();
     }
 }

--- a/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/services/impl/FavoriteServiceImpl.java
+++ b/demand-capacity-mgmt-backend/src/main/java/org/eclipse/tractusx/demandcapacitymgmt/demandcapacitymgmtbackend/services/impl/FavoriteServiceImpl.java
@@ -49,7 +49,8 @@ public class FavoriteServiceImpl implements FavoriteService {
 
     @Override
     public List<FavoriteResponse> getAllFavoritesByType(FavoriteType type) {
-        return null;
+        List<FavoriteEntity> favoriteEntities = favoriteRepository.findByType(type);
+        return favoriteEntities.stream().map(this::convertFavoriteResponse).toList();
     }
 
     @Override

--- a/demand-capacity-mgmt-backend/src/main/resources/db/migration/V202309041618__8_create_favorites_table.sql
+++ b/demand-capacity-mgmt-backend/src/main/resources/db/migration/V202309041618__8_create_favorites_table.sql
@@ -20,7 +20,7 @@
  *    ********************************************************************************
  */
 
- create table favorites
+ create table  if not exists favorites
  (
      user_id uuid primary key,
      favorite_id uuid,

--- a/demand-capacity-mgmt-backend/src/main/resources/db/migration/V202309041618__8_create_favorites_table.sql
+++ b/demand-capacity-mgmt-backend/src/main/resources/db/migration/V202309041618__8_create_favorites_table.sql
@@ -1,0 +1,28 @@
+/*
+ *  *******************************************************************************
+ *  Copyright (c) 2023 BMW AG
+ *  Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ *    See the NOTICE file(s) distributed with this work for additional
+ *    information regarding copyright ownership.
+ *
+ *    This program and the accompanying materials are made available under the
+ *    terms of the Apache License, Version 2.0 which is available at
+ *    https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ *
+ *    SPDX-License-Identifier: Apache-2.0
+ *    ********************************************************************************
+ */
+
+ create table favorites
+ (
+     userID uuid primary key,
+     favoriteID uuid,
+     type varchar(30)
+ );

--- a/demand-capacity-mgmt-backend/src/main/resources/db/migration/V202309041618__8_create_favorites_table.sql
+++ b/demand-capacity-mgmt-backend/src/main/resources/db/migration/V202309041618__8_create_favorites_table.sql
@@ -22,7 +22,7 @@
 
  create table favorites
  (
-     userID uuid primary key,
-     favoriteID uuid,
-     type varchar(30)
+     user_id uuid primary key,
+     favorite_id uuid,
+     f_type varchar(30)
  );

--- a/demand-capacity-mgmt-specification/src/main/resources/openapi.yml
+++ b/demand-capacity-mgmt-specification/src/main/resources/openapi.yml
@@ -299,6 +299,19 @@ paths:
         - favorite
       summary: Update a Favorite
       operationId: updateFavorite
+      parameters:
+        - name: id
+          in: query
+          required: true
+          description: ID of the favorite to update
+          schema:
+            type: string
+        - name: type
+          in: query
+          required: true
+          description: type of the favorite to update
+          schema:
+            type: string
       requestBody:
         required: true
         content:
@@ -319,15 +332,9 @@ paths:
       operationId: deleteFavoriteById
       parameters:
         - name: id
-          in: path
+          in: query
           required: true
           description: ID of the favorite to delete
-          schema:
-            type: string
-        - name: type
-          in: path
-          required: true
-          description: type of the favorite to delete
           schema:
             type: string
       responses:

--- a/demand-capacity-mgmt-specification/src/main/resources/openapi.yml
+++ b/demand-capacity-mgmt-specification/src/main/resources/openapi.yml
@@ -324,6 +324,12 @@ paths:
           description: ID of the favorite to delete
           schema:
             type: string
+        - name: type
+          in: path
+          required: true
+          description: type of the favorite to delete
+          schema:
+            type: string
       responses:
         200:
           description: Favorite deleted successfully

--- a/demand-capacity-mgmt-specification/src/main/resources/openapi.yml
+++ b/demand-capacity-mgmt-specification/src/main/resources/openapi.yml
@@ -261,6 +261,100 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/DemandCategoryResponse'
+  /favorite:
+    get:
+      tags:
+        - favorite
+      summary: get all favorites
+      operationId: getFavorite
+      responses:
+        200:
+          description: favorite response array
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FavoriteResponse'
+    post:
+      tags:
+        - favorite
+      summary: Create a New Favorite
+      operationId: createFavorite
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FavoriteRequest'
+      responses:
+        200:
+          description: Favorite created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FavoriteResponse'
+    put:
+      tags:
+        - favorite
+      summary: Update a Favorite
+      operationId: updateFavorite
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FavoriteRequest'
+      responses:
+        200:
+          description: Favorite updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FavoriteResponse'
+    delete:
+      tags:
+        - favorite
+      summary: Delete a Favorite by ID
+      operationId: deleteFavoriteById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of the favorite to delete
+          schema:
+            type: string
+      responses:
+        200:
+          description: Favorite deleted successfully
+        404:
+          description: Favorite not found
+
+
+  /favorite/{type}:
+    get:
+      tags:
+        - favorite
+      summary: Get a Favorite by type
+      operationId: getFavoriteByType
+      parameters:
+        - name: type
+          in: path
+          required: true
+          description: type of the favorite
+          schema:
+            type: string
+      responses:
+        200:
+          description: Favorite found
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FavoriteResponse'
+        404:
+          description: Favorite not found
 
 components:
   schemas:
@@ -667,6 +761,18 @@ components:
         name:
           type: string
 
+    FavoriteRequest:
+      type: object
+      properties:
+        favoriteId:
+          type: string
+        fType:
+          type: string
 
-
-
+    FavoriteResponse:
+      type: object
+      properties:
+        favoriteId:
+          type: string
+        fType:
+          type: string


### PR DESCRIPTION
Created the back-bone of the favorite service
the user can save favorites based on type (demand,material,product,etc) 
since there are no users in this back-end yet, all create and update are mocked with a hardcoded UUID for user.
this is all that is left to implement, the user identifier.
