### PR TITLE
Added NOTICE.md files next to dockerfiles

### DIFF
--- a/build/backend/NOTICE.md
+++ b/build/backend/NOTICE.md
@@ -1,0 +1,10 @@
+DockerHub: [https://hub.docker.com/r/tractusx/demand-capacity-mgmt-backend](https://hub.docker.com/r/tractusx/demand-capacity-mgmt-backend)
+
+Eclipse Tractus-X product(s) installed within the image:
+
+__Demand Capacity Management Backend__
+
+- GitHub: [https://github.com/eclipse-tractusx/demand-capacity-mgmt-backend](https://github.com/eclipse-tractusx/demand-capacity-mgmt-backend)
+- Project home: [https://projects.eclipse.org/projects/automotive.tractusx](https://projects.eclipse.org/projects/automotive.tractusx)
+- Dockerfile: [https://github.com/eclipse-tractusx/demand-capacity-mgmt-backend/blob/main/Dockerfile](https://github.com/eclipse-tractusx/demand-capacity-mgmt-backend/blob/main/Dockerfile)
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/demand-capacity-mgmt-backend/blob/main/LICENSE)

--- a/build/backend/NOTICE.md
+++ b/build/backend/NOTICE.md
@@ -4,7 +4,13 @@ Eclipse Tractus-X product(s) installed within the image:
 
 __Demand Capacity Management Backend__
 
-- GitHub: [https://github.com/eclipse-tractusx/demand-capacity-mgmt-backend](https://github.com/eclipse-tractusx/demand-capacity-mgmt-backend)
+- GitHub: [https://github.com/eclipse-tractusx/demand-capacity-mgmt](https://github.com/eclipse-tractusx/demand-capacity-mgmt)
 - Project home: [https://projects.eclipse.org/projects/automotive.tractusx](https://projects.eclipse.org/projects/automotive.tractusx)
-- Dockerfile: [https://github.com/eclipse-tractusx/demand-capacity-mgmt-backend/blob/main/Dockerfile](https://github.com/eclipse-tractusx/demand-capacity-mgmt-backend/blob/main/Dockerfile)
-- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/demand-capacity-mgmt-backend/blob/main/LICENSE)
+- Dockerfile: [https://github.com/eclipse-tractusx/demand-capacity-mgmt/blob/main/build/backend/Dockerfile](https://github.com/eclipse-tractusx/demand-capacity-mgmt/blob/main/build/backend/Dockerfile)
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/demand-capacity-mgmt/blob/main/LICENSE)
+
+
+As with all Docker images, these likely also contain other software which may be under other licenses
+(such as Bash, etc. from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.

--- a/build/frontend/NOTICE.md
+++ b/build/frontend/NOTICE.md
@@ -6,7 +6,12 @@ Eclipse Tractus-X product(s) installed within the image:
 
 __Demand Capacity Management Frontend__
 
-- GitHub: [https://github.com/eclipse-tractusx/demand-capacity-mgmt-frontend](https://github.com/eclipse-tractusx/demand-capacity-mgmt-frontend)
+- GitHub: [https://github.com/eclipse-tractusx/demand-capacity-mgmt](https://github.com/eclipse-tractusx/demand-capacity-mgmt)
 - Project home: [https://projects.eclipse.org/projects/automotive.tractusx](https://projects.eclipse.org/projects/automotive.tractusx)
-- Dockerfile: [https://github.com/eclipse-tractusx/demand-capacity-mgmt-frontend/blob/main/Dockerfile](https://github.com/eclipse-tractusx/demand-capacity-mgmt-frontend/blob/main/Dockerfile)
-- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/demand-capacity-mgmt-frontend/blob/main/LICENSE)
+- Dockerfile: [https://github.com/eclipse-tractusx/demand-capacity-mgmt/blob/main/build/frontend/Dockerfile](https://github.com/eclipse-tractusx/demand-capacity-mgmt/blob/main/build/frontend/Dockerfile)
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/demand-capacity-mgmt/blob/main/LICENSE)
+
+As with all Docker images, these likely also contain other software which may be under other licenses
+(such as Bash, etc. from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.

--- a/build/frontend/NOTICE.md
+++ b/build/frontend/NOTICE.md
@@ -1,0 +1,12 @@
+## Notice for Docker image
+
+DockerHub: [https://hub.docker.com/r/tractusx/demand-capacity-mgmt-frontend](https://hub.docker.com/r/tractusx/demand-capacity-mgmt-frontend)
+
+Eclipse Tractus-X product(s) installed within the image:
+
+__Demand Capacity Management Frontend__
+
+- GitHub: [https://github.com/eclipse-tractusx/demand-capacity-mgmt-frontend](https://github.com/eclipse-tractusx/demand-capacity-mgmt-frontend)
+- Project home: [https://projects.eclipse.org/projects/automotive.tractusx](https://projects.eclipse.org/projects/automotive.tractusx)
+- Dockerfile: [https://github.com/eclipse-tractusx/demand-capacity-mgmt-frontend/blob/main/Dockerfile](https://github.com/eclipse-tractusx/demand-capacity-mgmt-frontend/blob/main/Dockerfile)
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/demand-capacity-mgmt-frontend/blob/main/LICENSE)


### PR DESCRIPTION

This PR serves to help keep our project aligned with the TRGs and other open-source policies.

In this case, we have created and added the NOTICE.md files, to the build folder, next to the dockerfiles.

fix #39 