### PR TITLE
Issue legal information for distribution missing

### DIFF
--- a/build/backend/NOTICE.md
+++ b/build/backend/NOTICE.md
@@ -1,0 +1,10 @@
+DockerHub: [https://hub.docker.com/r/tractusx/demand-capacity-mgmt-backend](https://hub.docker.com/r/tractusx/demand-capacity-mgmt-backend)
+
+Eclipse Tractus-X product(s) installed within the image:
+
+__Demand Capacity Management Backend__
+
+- GitHub: [https://github.com/eclipse-tractusx/demand-capacity-mgmt-backend](https://github.com/eclipse-tractusx/demand-capacity-mgmt-backend)
+- Project home: [https://projects.eclipse.org/projects/automotive.tractusx](https://projects.eclipse.org/projects/automotive.tractusx)
+- Dockerfile: [https://github.com/eclipse-tractusx/demand-capacity-mgmt-backend/blob/main/Dockerfile](https://github.com/eclipse-tractusx/demand-capacity-mgmt-backend/blob/main/Dockerfile)
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/demand-capacity-mgmt-backend/blob/main/LICENSE)

--- a/build/frontend/NOTICE.md
+++ b/build/frontend/NOTICE.md
@@ -1,0 +1,12 @@
+## Notice for Docker image
+
+DockerHub: [https://hub.docker.com/r/tractusx/demand-capacity-mgmt-frontend](https://hub.docker.com/r/tractusx/demand-capacity-mgmt-frontend)
+
+Eclipse Tractus-X product(s) installed within the image:
+
+__Demand Capacity Management Frontend__
+
+- GitHub: [https://github.com/eclipse-tractusx/demand-capacity-mgmt-frontend](https://github.com/eclipse-tractusx/demand-capacity-mgmt-frontend)
+- Project home: [https://projects.eclipse.org/projects/automotive.tractusx](https://projects.eclipse.org/projects/automotive.tractusx)
+- Dockerfile: [https://github.com/eclipse-tractusx/demand-capacity-mgmt-frontend/blob/main/Dockerfile](https://github.com/eclipse-tractusx/demand-capacity-mgmt-frontend/blob/main/Dockerfile)
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/demand-capacity-mgmt-frontend/blob/main/LICENSE)

--- a/demand-capacity-mgmt-backend/pom.xml
+++ b/demand-capacity-mgmt-backend/pom.xml
@@ -191,6 +191,28 @@
                 </configuration>
             </plugin>
         </plugins>
+        <resources>
+            <!-- add basic application properties -->
+            <resource>
+                <directory>${project.basedir}/src/main/resources</directory>
+                <includes>
+                    <include>application.properties</include>
+                </includes>
+                <targetPath>BOOT-INF/classes/</targetPath>
+            </resource>
+            <!-- add legal information to META-INF -->
+            <resource>
+                <directory>${project.basedir}/</directory>
+                <includes>
+                    <include>README.md</include>
+                    <include>LICENSE</include>
+                    <include>NOTICE.md</include>
+                    <include>DEPENDENCIES</include>
+                    <include>SECURITY.md</include>
+                </includes>
+                <targetPath>META-INF</targetPath>
+            </resource>
+        </resources>
     </build>
     <repositories>
         <repository>


### PR DESCRIPTION
This PR serves to help keep our project aligned with the TRGs and other open-source policies.

In this case, we have configured the main  pom.xml file for generating the legal information to the .jars.

fix #47 