### PR TITLE
Update pom.xml to add legal information to META-INF

### DIFF
--- a/demand-capacity-mgmt-backend/pom.xml
+++ b/demand-capacity-mgmt-backend/pom.xml
@@ -195,6 +195,28 @@
                 </configuration>
             </plugin>
         </plugins>
+        <resources>
+            <!-- add basic application properties -->
+            <resource>
+                <directory>${project.basedir}/src/main/resources</directory>
+                <includes>
+                    <include>application.properties</include>
+                </includes>
+                <targetPath>BOOT-INF/classes/</targetPath>
+            </resource>
+            <!-- add legal information to META-INF -->
+            <resource>
+                <directory>${project.basedir}/</directory>
+                <includes>
+                    <include>README.md</include>
+                    <include>LICENSE</include>
+                    <include>NOTICE.md</include>
+                    <include>DEPENDENCIES</include>
+                    <include>SECURITY.md</include>
+                </includes>
+                <targetPath>META-INF</targetPath>
+            </resource>
+        </resources>
     </build>
     <repositories>
         <repository>


### PR DESCRIPTION
This PR serves to help keep our project aligned with the TRGs and other open-source policies.

In this case, we have configured the main pom.xml file for generating the legal information to the .jars.

fix #47 