### PR TITLE
(doc) Translation: BKM -> DCM

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Turbulence in the global economy, technological change, and limited availability
 
 # Resilient supply chains
 
-Demand and capacity management (BKM) is based on a collaborative process. Those who are part of the Catena-X network can securely share their demand and capacity data with other collaborators: with suppliers just as much as with automotive manufacturers and recyclers.
+Demand and capacity management (DCM) is based on a collaborative process. Those who are part of the Catena-X network can securely share their demand and capacity data with other collaborators: with suppliers just as much as with automotive manufacturers and recyclers.
 
 The Catena-X ecosystem offers protected spaces with a common view of the data released. This enables the partners to react at an early stage to changes in plans and deviations and to jointly find a solution based on the situation.
 


### PR DESCRIPTION
## Description 
Changed BKM to DCM. The German acronym BKM for
Bedarf- und Kapazitaets-Management was still used
as acronym for Demand and Capacity Management in
the README. Changed one instance.

## Pre-review checks
- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
