### PR TITLE
Feat/dependabot config added

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,22 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "maven" # See documentation for possible values
-    directory: "/demand-capacity-mgmt-backend" # Location of package manifests
+  - package-ecosystem: "maven"
+    directory: "/demand-capacity-mgmt-backend"
     schedule:
       interval: "daily"
-  - package-ecosystem: "maven" # See documentation for possible values
-    directory: "/demand-capacity-mgmt-specification" # Location of package manifests
+    open-pull-requests-limit: 5
+  - package-ecosystem: "maven"
+    directory: "/demand-capacity-mgmt-specification"
     schedule:
       interval: "daily"
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/demand-capacity-mgmt-frontend" # Location of package manifests
+    open-pull-requests-limit: 5
+  - package-ecosystem: "npm"
+    directory: "/demand-capacity-mgmt-frontend"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 5
   - package-ecosystem: "docker"
-    # Look for a `Dockerfile` in the `root` directory
     directory: "/"
-    # Check for updates once a week
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,3 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 5
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,21 @@
+# *******************************************************************************
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+#   See the NOTICE file(s) distributed with this work for additional
+#   information regarding copyright ownership.
+#
+#   This program and the accompanying materials are made available under the
+#   terms of the Apache License, Version 2.0 which is available at
+#   https://www.apache.org/licenses/LICENSE-2.0.
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+#
+#   SPDX-License-Identifier: Apache-2.0
+#   ********************************************************************************
 version: 2
 updates:
   - package-ecosystem: "maven"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "maven" # See documentation for possible values
+    directory: "/demand-capacity-mgmt-backend" # Location of package manifests
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "maven" # See documentation for possible values
+    directory: "/demand-capacity-mgmt-specification" # Location of package manifests
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/demand-capacity-mgmt-frontend" # Location of package manifests
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    # Look for a `Dockerfile` in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION

## Description
Dependabot config added to address [TRG 2.06 - Dependabot](https://eclipse-tractusx.github.io/docs/release/trg-2/trg-2-6/)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
